### PR TITLE
Update Task Editor UI

### DIFF
--- a/src/widgets/Course/QuestionBank/TaskEdit/QuestionPanel.tsx
+++ b/src/widgets/Course/QuestionBank/TaskEdit/QuestionPanel.tsx
@@ -1,0 +1,28 @@
+import {Flex, Button} from 'antd';
+import {CheckCircleOutlined, CheckSquareOutlined} from 'react-icons/all';
+import {MdOutlineTextFields} from 'react-icons/md';
+import {AiOutlineFieldBinary} from 'react-icons/ai';
+import {HiSelector} from 'react-icons/hi';
+import {PiTextAlignJustifyThin} from 'react-icons/pi';
+import {BiTransfer} from 'react-icons/bi';
+import {EditorContentProps} from '@tiptap/react';
+import {pasteEmptyQuestion} from '../../../TipTap/Menus/handlers/PasteEmptyQuestion';
+import {ChoiceType} from '../../../../shared/types/CourseTypes';
+
+export default function QuestionPanel({editor}: {editor: EditorContentProps['editor']}) {
+  if (!editor) return null;
+  const insert = (key: ChoiceType) => {
+    editor.chain().focus().insertContent(pasteEmptyQuestion(key)).run();
+  };
+  return (
+    <Flex vertical gap={8} style={{padding: 8}}>
+      <Button onClick={() => insert('mono')} icon={<CheckCircleOutlined/>}>Один ответ</Button>
+      <Button onClick={() => insert('multi')} icon={<CheckSquareOutlined/>}>Несколько ответов</Button>
+      <Button onClick={() => insert('text')} icon={<MdOutlineTextFields/>}>Короткий текст</Button>
+      <Button onClick={() => insert('number')} icon={<AiOutlineFieldBinary/>}>Число</Button>
+      <Button onClick={() => insert('select')} icon={<HiSelector/>}>Выбор из списка</Button>
+      <Button onClick={() => insert('textarea')} icon={<PiTextAlignJustifyThin/>}>Длинный текст</Button>
+      <Button disabled icon={<BiTransfer/>}>Порядок элементов</Button>
+    </Flex>
+  );
+}

--- a/src/widgets/Course/QuestionBank/TaskEdit/TaskEdit.tsx
+++ b/src/widgets/Course/QuestionBank/TaskEdit/TaskEdit.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useLayoutEffect} from "react";
-import {Button, Flex} from "antd";
+import {Button, Flex, Splitter} from "antd";
 import {GrTest} from "react-icons/gr";
 import {EditorContent} from '@tiptap/react'
 import {useShallow} from "zustand/react/shallow";
@@ -13,6 +13,7 @@ import BubbleMenu from "../../../TipTap/Menus/BubbleMenu.tsx";
 import {Knowledge} from "../../../../shared/types/CourseTypes.ts";
 import EditEditor from "../../../TipTap/Questions/Editable/EditEditor.ts";
 import {getQuestions} from "../getQuestions.ts";
+import QuestionPanel from "./QuestionPanel";
 import 'katex/dist/katex.min.css'
 
 const TaskEdit = () => {
@@ -72,39 +73,41 @@ const TaskEdit = () => {
 
   return (
     <EditorProvider editor={editor}>
-      <Flex gap={8} vertical style={{padding: 32}}>
-        <Flex gap={8} justify={'end'}>
-          <Button
-            icon={<GrTest />}
-            type={'default'}
-            onClick={() => {
-              saveTask();
-              setTaskTestMode(true);
-              setActiveTab('task-test');
-            }}
-          >
-            Протестировать
-          </Button>
-          <Button
-            type={'primary'}
-            onClick={() => {
-              saveTask();
-              setTaskEditMode(false);
-              setActiveTab('task-bank');
-            }}>
-            Сохранить
-          </Button>
-        </Flex>
-        <ToolBox editor={editor}/>
-        <BubbleMenu editor={editor}/>
-        {/*<FloatingMenuEditor editor={editor}/>*/}
-        <EditorContent editor={editor}/>
-        <button onClick={() => {
-          console.log(editor?.getJSON())
-        }}>
-          Get JSON
-        </button>
-      </Flex>
+      <Splitter style={{height: '100%'}}>
+        <Splitter.Panel>
+          <Flex gap={8} vertical style={{padding: 16, height: '100%'}}>
+            <Flex gap={8} justify={'end'}>
+              <Button
+                icon={<GrTest />}
+                type={'default'}
+                onClick={() => {
+                  saveTask();
+                  setTaskTestMode(true);
+                  setActiveTab('task-test');
+                }}
+              >
+                Протестировать
+              </Button>
+              <Button
+                type={'primary'}
+                onClick={() => {
+                  saveTask();
+                  setTaskEditMode(false);
+                  setActiveTab('task-bank');
+                }}>
+                Сохранить
+              </Button>
+            </Flex>
+            <ToolBox editor={editor}/>
+            <BubbleMenu editor={editor}/>
+            {/*<FloatingMenuEditor editor={editor}/>*/}
+            <EditorContent editor={editor}/>
+          </Flex>
+        </Splitter.Panel>
+        <Splitter.Panel collapsible defaultSize={'25%'} min={'15%'} max={'35%'}>
+          <QuestionPanel editor={editor}/>
+        </Splitter.Panel>
+      </Splitter>
     </EditorProvider>
   )
 }

--- a/src/widgets/TipTap/Menus/Nodes/Media.tsx
+++ b/src/widgets/TipTap/Menus/Nodes/Media.tsx
@@ -1,0 +1,39 @@
+import {useState} from 'react';
+import {Button, Popover, Upload} from 'antd';
+import {UploadOutlined} from '@ant-design/icons';
+import type {UploadProps} from 'antd';
+import {EditorContentProps} from '@tiptap/react';
+
+export default function Media({editor}: {editor: EditorContentProps['editor']}) {
+  const [open, setOpen] = useState(false);
+  if (!editor) return null;
+
+  const props: UploadProps = {
+    showUploadList: false,
+    beforeUpload: file => {
+      const reader = new FileReader();
+      reader.onload = e => {
+        const src = e.target?.result as string;
+        if (!src) return;
+        let tag = 'img';
+        if (file.type.startsWith('audio')) tag = 'audio';
+        if (file.type.startsWith('video')) tag = 'video';
+        const html = tag === 'img'
+          ? `<img src="${src}" alt="${file.name}" />`
+          : `<${tag} controls src="${src}"></${tag}>`;
+        editor.chain().focus().insertContent(html).run();
+      };
+      reader.readAsDataURL(file);
+      setOpen(false);
+      return false;
+    },
+  };
+
+  const content = <Upload {...props}><Button icon={<UploadOutlined/>}>Загрузить</Button></Upload>;
+
+  return (
+    <Popover title='Медиа' content={content} open={open} onOpenChange={setOpen} trigger='click'>
+      <Button icon={<UploadOutlined/>}/>
+    </Popover>
+  );
+}

--- a/src/widgets/TipTap/Menus/ToolBox.tsx
+++ b/src/widgets/TipTap/Menus/ToolBox.tsx
@@ -5,11 +5,14 @@ import {
   ItalicOutlined,
   OrderedListOutlined,
   StrikethroughOutlined,
-  UnorderedListOutlined
+  UnorderedListOutlined,
+  UnderlineOutlined,
+  UndoOutlined,
+  RedoOutlined
 } from "@ant-design/icons";
 import {EditorContentProps} from "@tiptap/react";
 import Link from "./Marks/Link";
-import Image from "./Nodes/Image";
+import Media from "./Nodes/Media";
 import Formula from "./Nodes/Formula";
 import PasteQuestion from "./Nodes/Question.tsx";
 
@@ -21,6 +24,12 @@ export default function ToolBox({editor}: { editor: EditorContentProps['editor']
   return (
     <Space split={<Divider/>} wrap>
       <Space.Compact>
+        <Button icon={<UndoOutlined/>}
+                onClick={() => editor?.chain().focus().undo().run()}
+                disabled={!editor.can().chain().focus().undo().run()}/>
+        <Button icon={<RedoOutlined/>}
+                onClick={() => editor?.chain().focus().redo().run()}
+                disabled={!editor.can().chain().focus().redo().run()}/>
         <Button icon={<BoldOutlined/>}
                 onClick={() => editor?.chain().focus().toggleBold().run()}
                 disabled={!editor.can().chain().focus().toggleBold().run()}
@@ -33,6 +42,10 @@ export default function ToolBox({editor}: { editor: EditorContentProps['editor']
                 onClick={() => editor?.chain().focus().toggleStrike().run()}
                 disabled={!editor.can().chain().focus().toggleStrike().run()}
                 type={editor.isActive('strike') ? 'primary' : 'default'}/>
+        <Button icon={<UnderlineOutlined/>}
+                onClick={() => editor?.chain().focus().toggleUnderline().run()}
+                disabled={!editor.can().chain().focus().toggleUnderline().run()}
+                type={editor.isActive('underline') ? 'primary' : 'default'}/>
         <Button icon={<CodeOutlined/>}
                 onClick={() => editor?.chain().focus().toggleCode().run()}
                 disabled={!editor.can().chain().focus().toggleCode().run()}
@@ -51,7 +64,7 @@ export default function ToolBox({editor}: { editor: EditorContentProps['editor']
       <Space.Compact>
         <Link editor={editor}/>
         <Formula editor={editor}/>
-        <Image editor={editor}/>
+        <Media editor={editor}/>
       </Space.Compact>
       <Space.Compact direction={'horizontal'}>
         <PasteQuestion editor={editor}/>

--- a/src/widgets/TipTap/Questions/Editable/EditEditor.ts
+++ b/src/widgets/TipTap/Questions/Editable/EditEditor.ts
@@ -4,6 +4,7 @@ import {Mathematics} from "@tiptap-pro/extension-mathematics";
 import Placeholder from "@tiptap/extension-placeholder";
 import Link from "@tiptap/extension-link";
 import EditComponent from "./EditComponent.tsx";
+import Underline from "../../extensions/Underline";
 import styles from "../../../../shared/styles/Editor.module.css";
 
 export default function EditEditor(): EditorContentProps['editor'] {
@@ -14,6 +15,7 @@ export default function EditEditor(): EditorContentProps['editor'] {
     extensions: [
       StarterKit,
       Mathematics,
+      Underline,
       EditComponent(),
       Placeholder.configure(
         {

--- a/src/widgets/TipTap/extensions/Underline.ts
+++ b/src/widgets/TipTap/extensions/Underline.ts
@@ -1,0 +1,36 @@
+import {Mark} from '@tiptap/core';
+
+const Underline = Mark.create({
+  name: 'underline',
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+  parseHTML() {
+    return [
+      { tag: 'u' },
+      {
+        style: 'text-decoration',
+        consuming: false,
+        getAttrs: (value) =>
+          (value as string).includes('underline') ? null : false,
+      },
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['u', { ...this.options.HTMLAttributes, ...HTMLAttributes }, 0];
+  },
+  addCommands() {
+    return {
+      toggleUnderline: () => ({ commands }) => commands.toggleMark(this.name),
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      'Mod-u': () => this.editor.commands.toggleUnderline(),
+    };
+  },
+});
+
+export default Underline;


### PR DESCRIPTION
## Summary
- add media popover with upload support
- add underline extension
- extend TipTap toolbar with undo/redo/underline/media
- split task editor screen with right panel to insert questions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853286ebfe08325a3b7b25b7729615a